### PR TITLE
docs(i18n): Standardize comments to Brazilian Portuguese

### DIFF
--- a/src/i18n/navigation.ts
+++ b/src/i18n/navigation.ts
@@ -1,6 +1,6 @@
 import { createNavigation } from 'next-intl/navigation';
 import { routing } from './routing';
 
-// Lightweight wrappers around Next.js' navigation
-// APIs that consider the routing configuration
+// Wrappers leves em torno das APIs de navegação do Next.js
+// que consideram a configuração de rotas
 export const { Link, redirect, usePathname, useRouter, getPathname } = createNavigation(routing);

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -2,10 +2,10 @@ import { getRequestConfig } from 'next-intl/server';
 import { routing } from './routing';
 
 export default getRequestConfig(async ({ requestLocale }) => {
-  // This typically corresponds to the `[locale]` segment
+  // Isto normalmente corresponde ao `[locale]`
   let locale = await requestLocale;
 
-  // Ensure that a valid locale is used
+  // Garante que um locale válido seja usado
   if (!locale || !routing.locales.includes(locale as (typeof routing.locales)[number])) {
     locale = routing.defaultLocale;
   }

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -1,9 +1,9 @@
 import { defineRouting } from 'next-intl/routing';
 
 export const routing = defineRouting({
-  // A list of all locales that are supported
+  // Lista de todos os idiomas suportados
   locales: ['pt', 'en', 'es'],
 
-  // Used when no locale matches
+  // Usado quando nenhum idioma corresponde
   defaultLocale: 'pt',
 });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,8 +4,8 @@ import { routing } from './i18n/routing';
 export default createMiddleware(routing);
 
 export const config = {
-  // Match all pathnames except for
-  // - … if they start with `/api`, `/trpc`, `/_next` or `/_vercel`
-  // - … the ones containing a dot (e.g. `favicon.ico`)
+  // Corresponder a todos os caminhos exceto para
+  // - … se eles começarem com `/api`, `/trpc`, `/_next` ou `/_vercel`
+  // - … aqueles que contenham um ponto (ex: `favicon.ico`)
   matcher: '/((?!api|trpc|_next|_vercel|.*\\..*).*)',
 };


### PR DESCRIPTION
Translate English comments in i18n configuration files

request.ts: translate comments about locale and validation

routing.ts: translate comments about supported languages list

middleware.ts: translate comments about path matching

navigation.ts: keep comments already in Portuguese

Improve consistency of internal code documentation